### PR TITLE
Fixes utils export

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "prettier": {
     "printWidth": 80,
     "semi": true,
+    "endOfLine": "auto",
     "singleQuote": true,
     "trailingComma": "es5"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './automapper.module';
 export * from './interfaces';
+export * from './utils';
 export * from './decorators';
 export {
   AutoMapper,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,4 @@
+export * from './getMapperToken';
+export * from './getWithMapperArgs';
+export * from './mapperMap';
+export * from './profileMap';


### PR DESCRIPTION
I think e.g. getMapperToken sometimes is needed to inject a different, named automapper.